### PR TITLE
fix: harden nil handling; deterministic field output; chain-aware Is* helpers (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-07-03
+### Changed
+- `IsCustomError`, `To`, `IsHTTPStatus`, `IsErrorCode`, and `IsRetryable` now
+  traverse the error chain (`errors.As`), so a `CustomError` wrapped via
+  `fmt.Errorf("%w")` or `Wrap` is found too. `From` intentionally keeps its
+  previous semantics (only a direct `*CustomError` is treated specially).
+- `Error()`/`APIError()` field output is now deterministic: fields are sorted
+  by key (previously the order was random for more than one field).
+
+### Fixed
+- `Catalog.Set` no longer stores a nil entry when an ignore option
+  (`WithIgnoreFunc`/`WithIgnoreString`) fires; it returns the new
+  `ErrCatalogNilEntry` error instead (previously a later `Catalog.Get`/`MustGet`
+  on that code panicked with a nil-pointer dereference).
+- `Catalog.Get` no longer panics on a nil or non-`CustomError` entry stored
+  directly into the map; it returns `ErrCatalogErrorNotFound`.
+- `Wrap` no longer panics when `customError` is nil: the first non-nil
+  additional error takes its place, and if every error is nil, `Wrap` returns
+  nil. With nothing to wrap, the single error is returned as-is instead of
+  emitting a dangling `". Wrapped Error(s): "` suffix.
+- `Copy` is now nil-safe: a nil `src` is a no-op and a nil `target` is
+  replaced with a fresh `CustomError` (previously both panicked).
+
 ## [2.0.0] - 2026-05-30
 ### Changed
 - **BREAKING:** module path is now `github.com/thalesfsp/customerror/v2`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,8 @@ the `/v2` suffix; the package name is still `customerror`).
   precedence — it is load-bearing.
 
 ## Gotchas
-- `Error()` output is non-deterministic for >1 field (`sync.Map` range order);
-  assert with `strings.Contains`, not equality.
+- `Error()` field output is deterministic since v2.1.0: fields are sorted by
+  key (`. Fields: a=1, b=2`); tags are sorted too (treeset).
 - `example_test.go` asserts EXACT stdout — any message-format change breaks it.
 - The template singleton (`languageprefixtemplate.go`) is package-global and
   persists across tests. In tests, register/use UNIQUE language codes (e.g.

--- a/bugfixes_test.go
+++ b/bugfixes_test.go
@@ -662,3 +662,205 @@ func TestFix_Sanity_SetStringDeterministic(t *testing.T) {
 	e := New("msg", WithTag("b", "a", "c")).(*CustomError)
 	assert.Equal(t, "a, b, c", strings.TrimSpace(e.Tags.String()))
 }
+
+//////
+// #22 - Catalog.Set must not store a nil entry when an ignore option fires;
+// Catalog.Get must never panic on a nil/foreign entry.
+//////
+
+func TestFix_CatalogSet_NilEntryRejected(t *testing.T) {
+	c := MustNewCatalog("myapp")
+
+	// Bad path (pre-fix: stored nil, then Get panicked): an ignore option that
+	// fires makes Factory return nil; Set must reject it with an error.
+	code, err := c.Set("IGNORED_CODE", "some message", WithIgnoreString("some"))
+	require.Error(t, err)
+	assert.Empty(t, code)
+	assert.True(t, IsErrorCode(err, "CE_ERR_CATALOG_NIL_ENTRY"))
+
+	// Nothing was stored.
+	_, err = c.Get("IGNORED_CODE")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCatalogErrorNotFound)
+
+	// Edge: a nil entry stored directly into the map (bypassing Set) must not
+	// panic Get either.
+	c.ErrorCodeErrorMap.Store(ErrorCode("POISONED"), (*CustomError)(nil))
+
+	got, err := c.Get("POISONED")
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, ErrCatalogErrorNotFound)
+
+	// Happy path is unaffected.
+	code, err = c.Set("OK_CODE", "some message")
+	require.NoError(t, err)
+	assert.Equal(t, "OK_CODE", code)
+
+	entry, err := c.Get("OK_CODE")
+	require.NoError(t, err)
+	assert.Equal(t, "some message", entry.Message)
+}
+
+//////
+// #23 - Wrap must tolerate nil inputs, and must not emit a dangling
+// "Wrapped Error(s):" suffix when there is nothing to wrap.
+//////
+
+func TestFix_Wrap_NilSafety(t *testing.T) {
+	primary := New("primary", WithErrorCode("E1010"))
+	extra := errors.New("extra")
+
+	// Bad path (pre-fix: Error() nil-panicked): nil customError.
+	assert.NoError(t, Wrap(nil))
+	assert.NoError(t, Wrap(nil, nil, nil))
+
+	// Nil customError: the first non-nil error takes its place.
+	promoted := Wrap(nil, primary, extra)
+	require.Error(t, promoted)
+	assert.Equal(t, "E1010: primary. Wrapped Error(s): extra", promoted.Error())
+	assert.ErrorIs(t, promoted, primary)
+	assert.ErrorIs(t, promoted, extra)
+
+	// Edge: nothing to wrap - the error is returned as-is, so there is no
+	// dangling ". Wrapped Error(s): " suffix.
+	only := Wrap(primary)
+	require.Error(t, only)
+	assert.Equal(t, "E1010: primary", only.Error())
+	assert.ErrorIs(t, only, primary)
+}
+
+//////
+// #24 - Copy must be nil-safe.
+//////
+
+func TestFix_Copy_NilSafety(t *testing.T) {
+	// Bad path (pre-fix: nil-panicked).
+	target := &CustomError{}
+	assert.Same(t, target, Copy(nil, target))
+
+	// Edge: nil target gets a fresh CustomError.
+	src := Factory("some message", WithErrorCode("E1010"))
+	copied := Copy(src, nil)
+	require.NotNil(t, copied)
+	assert.Equal(t, "some message", copied.Message)
+	assert.Equal(t, "E1010", copied.Code)
+
+	// Edge: both nil.
+	assert.NotNil(t, Copy(nil, nil))
+}
+
+//////
+// #25 - IsCustomError/To/IsHTTPStatus/IsErrorCode/IsRetryable must see a
+// CustomError anywhere in the chain (errors.As), not only at the top level.
+//////
+
+func TestFix_IsHelpers_TraverseChain(t *testing.T) {
+	cE := New(
+		"some message",
+		WithStatusCode(http.StatusNotFound),
+		WithErrorCode("E1010"),
+		WithRetryable(true),
+	)
+
+	// Bad path (pre-fix: all of these returned false).
+	for name, wrapped := range map[string]error{
+		"fmt.Errorf": fmt.Errorf("outer: %w", cE),
+		"Wrap":       Wrap(errors.New("outer"), cE),
+	} {
+		assert.True(t, IsCustomError(wrapped), name)
+		assert.True(t, IsHTTPStatus(wrapped, http.StatusNotFound), name)
+		assert.True(t, IsErrorCode(wrapped, "E1010"), name)
+		assert.True(t, IsRetryable(wrapped), name)
+
+		found, ok := To(wrapped)
+		require.True(t, ok, name)
+		assert.Equal(t, "E1010", found.Code, name)
+	}
+
+	// Happy path: direct CustomError still matches.
+	assert.True(t, IsCustomError(cE))
+	assert.True(t, IsHTTPStatus(cE, http.StatusNotFound))
+
+	// Edge: plain errors still don't match.
+	plain := errors.New("plain")
+	assert.False(t, IsCustomError(plain))
+	assert.False(t, IsHTTPStatus(plain, http.StatusNotFound))
+	assert.False(t, IsErrorCode(plain, "E1010"))
+	assert.False(t, IsRetryable(plain))
+
+	// Edge: From still only treats a DIRECT CustomError specially - wrapping
+	// keeps the outer context.
+	fromWrapped := From(fmt.Errorf("outer: %w", cE))
+	assert.Contains(t, fromWrapped.Error(), "outer:")
+}
+
+//////
+// #26 - Error()/APIError() field output must be deterministic (sorted by
+// key), regardless of sync.Map range order.
+//////
+
+func TestFix_Fields_DeterministicOrder(t *testing.T) {
+	build := func() error {
+		return New("some message", WithFields(map[string]interface{}{
+			"zulu":  1,
+			"alpha": 2,
+			"mike":  3,
+		}))
+	}
+
+	want := "some message. Fields: alpha=2, mike=3, zulu=1"
+
+	// Pre-fix this was flaky: sync.Map range order is random.
+	for range 20 {
+		assert.Equal(t, want, build().Error())
+	}
+}
+
+//////
+// #27 - Concurrency: shared factory/catalog errors must be safe to use from
+// many goroutines (race detector must stay quiet).
+//////
+
+func TestFix_ConcurrentSharedErrorUsage(t *testing.T) {
+	factory := Factory(
+		"some message",
+		WithErrorCode("E1010"),
+		WithTag("tag1", "tag2"),
+		WithField("key1", "value1"),
+	)
+
+	catalog := MustNewCatalog("myapp")
+	catalog.MustSet("SOME_CODE", "some message", WithTag("tag1"), WithField("key1", "value1"))
+
+	var wg sync.WaitGroup
+
+	for i := range 50 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			// Factory methods on a shared error.
+			err := factory.NewFailedToError(WithField("goroutine", i), WithTag("extra"))
+			_ = err.Error()
+
+			// Catalog reads return independent copies.
+			cE := catalog.MustGet("SOME_CODE", WithField("goroutine", i))
+			_ = cE.Error()
+			_, _ = json.Marshal(cE) //nolint:errchkjson
+
+			// From on a shared sentinel returns a copy.
+			_ = From(factory, WithField("goroutine", i)).Error()
+
+			// Template reads.
+			_, _ = GetTemplate("en", FailedTo.String())
+		}()
+	}
+
+	wg.Wait()
+
+	// The shared instances were never mutated.
+	assert.Equal(t, "some message", factory.Message)
+	assert.Equal(t, "E1010: some message. Tags: tag1, tag2. Fields: key1=value1", factory.Error())
+}

--- a/catalog.go
+++ b/catalog.go
@@ -19,6 +19,11 @@ var (
 	// ErrCatalogInvalidName is returned when a catalog name is invalid.
 	ErrCatalogInvalidName = NewInvalidError("name", WithErrorCode("CE_ERR_CATALOG_INVALID_NAME"))
 
+	// ErrCatalogNilEntry is returned when the error being set resolves to nil
+	// - for example, when an ignore option (`WithIgnoreFunc`/`WithIgnoreString`)
+	// was triggered - and therefore cannot be stored in the catalog.
+	ErrCatalogNilEntry = NewInvalidError("entry. It resolves to nil (an ignore option was triggered?) and cannot be stored in the catalog", WithErrorCode("CE_ERR_CATALOG_NIL_ENTRY"))
+
 	// ErrErrorCodeInvalidCode is returned when an error code is invalid.
 	ErrErrorCodeInvalidCode = NewInvalidError("error code. It requires typeOf, and subject", WithErrorCode("CE_ERR_INVALID_ERROR_CODE"))
 
@@ -68,14 +73,21 @@ func (e ErrorCode) Validate() error {
 }
 
 // Set a custom error to the catalog. Use options to set default and common
-// values such as fields, tags, etc.
+// values such as fields, tags, etc. If the resulting error is nil (an ignore
+// option was triggered), nothing is stored and `ErrCatalogNilEntry` is
+// returned - a nil entry would otherwise panic on `Get`.
 func (c *Catalog) Set(errorCode string, defaultMessage string, opts ...Option) (string, error) {
 	eC, err := NewErrorCode(errorCode)
 	if err != nil {
 		return "", err
 	}
 
-	c.ErrorCodeErrorMap.Store(eC, Factory(defaultMessage, opts...))
+	cE := Factory(defaultMessage, opts...)
+	if cE == nil {
+		return "", ErrCatalogNilEntry
+	}
+
+	c.ErrorCodeErrorMap.Store(eC, cE)
 
 	return eC.String(), nil
 }
@@ -106,8 +118,15 @@ func (c *Catalog) Get(errorCode string, opts ...Option) (*CustomError, error) {
 		return nil, fmt.Errorf("%w. Code: %s", ErrCatalogErrorNotFound, errCode)
 	}
 
+	// Defensive: a non-CustomError or nil entry (e.g. stored directly into the
+	// map, bypassing `Set`) is treated as not found instead of panicking.
+	storedCE, ok := customErr.(*CustomError)
+	if !ok || storedCE == nil {
+		return nil, fmt.Errorf("%w. Code: %s", ErrCatalogErrorNotFound, errCode)
+	}
+
 	// Return a copy so the caller cannot mutate the catalog's stored entry.
-	cE := Copy(customErr.(*CustomError), &CustomError{})
+	cE := Copy(storedCE, &CustomError{})
 
 	// Apply the caller-provided options to the copy.
 	for _, opt := range opts {

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -1,0 +1,191 @@
+// Copyright 2021 The customerror Authors. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// Coverage tests for the less-traveled paths: nil receivers, panic paths
+// (Must* helpers), fallbacks, and defensive guards. Each block covers a happy
+// path, a bad path, and edge cases.
+
+package customerror
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//////
+// Catalog Must* helpers.
+//////
+
+func TestCoverage_CatalogMustHelpers(t *testing.T) {
+	// Happy path: MustSet returns the catalog for chaining, MustGet resolves.
+	c := MustNewCatalog("myapp")
+	assert.Same(t, c, c.MustSet("SOME_CODE", "some message"))
+	assert.Equal(t, "some message", c.MustGet("SOME_CODE").Message)
+
+	// Bad path: MustNewCatalog panics on an invalid (too short) name.
+	assert.Panics(t, func() { MustNewCatalog("ab") })
+
+	// Bad path: MustSet panics on an invalid error code.
+	assert.Panics(t, func() { c.MustSet("BAD CODE!", "some message") })
+
+	// Bad path: MustSet panics when the entry resolves to nil (ignore option).
+	assert.Panics(t, func() { c.MustSet("IGNORED", "some message", WithIgnoreString("some")) })
+
+	// Bad path: MustGet panics on a missing code.
+	assert.Panics(t, func() { _ = c.MustGet("DOES_NOT_EXIST") })
+
+	// Edge: Set with an invalid error code returns the error (no panic).
+	code, err := c.Set("BAD CODE!", "some message")
+	require.Error(t, err)
+	assert.Empty(t, code)
+	assert.ErrorIs(t, err, ErrErrorCodeInvalidCode)
+}
+
+//////
+// Language helpers: MustAddNewLanguage, GetRoot, GetLanguageErrorTypeMap.
+//////
+
+func TestCoverage_LanguageHelpers(t *testing.T) {
+	// Happy path: register a new language (unique code to avoid polluting the
+	// package-global template singleton for other tests).
+	assert.NotPanics(t, func() {
+		MustAddNewLanguage("yo", NewErrorPrefixMap(
+			"failed to %s", "invalid %s", "missing %s", "%s required", "%s not found",
+		))
+	})
+
+	tpl, err := GetTemplate("yo", FailedTo.String())
+	require.NoError(t, err)
+	assert.Equal(t, "failed to %s", tpl)
+
+	// Bad path: invalid language code panics.
+	assert.Panics(t, func() {
+		MustAddNewLanguage("not-a-lang", NewErrorPrefixMap("a %s", "b %s", "c %s", "d %s", "e %s"))
+	})
+
+	// Bad path: GetLanguageErrorTypeMap with an invalid code errors.
+	_, err = GetLanguageErrorTypeMap("not-a-lang")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidLanguageCode)
+
+	// Bad path: valid but unregistered language.
+	_, err = GetLanguageErrorTypeMap("xv")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrLanguageNotFound)
+
+	// Edge: GetRoot.
+	assert.Equal(t, "en", Language("en-US").GetRoot())
+	assert.Equal(t, "en", Language("en").GetRoot())
+	assert.Empty(t, Language("not-a-lang").GetRoot())
+}
+
+//////
+// Nil receivers: FormatError and the instance factory methods must return nil
+// instead of panicking.
+//////
+
+func TestCoverage_NilReceiverFactoryMethods(t *testing.T) {
+	var cE *CustomError
+
+	assert.Nil(t, cE.FormatError(FailedTo.String()))
+	assert.NoError(t, cE.NewFailedToError())
+	assert.NoError(t, cE.NewInvalidError())
+	assert.NoError(t, cE.NewMissingError())
+	assert.NoError(t, cE.NewRequiredError())
+	assert.NoError(t, cE.NewHTTPError(http.StatusNotFound))
+	assert.NoError(t, cE.New())
+}
+
+//////
+// FormatError: root-language fallback ("pt-BR" -> "pt") and missing-template
+// degradation.
+//////
+
+func TestCoverage_FormatError_RootFallback(t *testing.T) {
+	// Happy path: "pt-BR" has no template map of its own; the built-in "pt"
+	// root templates are used.
+	err := Factory(
+		"algo",
+		WithTranslation("pt-BR", "algo"),
+	).NewFailedToError(WithLanguage("pt-BR"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "falhou algo")
+
+	// Edge: a language with a translation but no templates at all degrades to
+	// the unprefixed message ("xv" is never registered).
+	err = Factory(
+		"algo",
+		WithTranslation("xv", "unprefixed message"),
+	).NewFailedToError(WithLanguage("xv"))
+
+	require.Error(t, err)
+	assert.Equal(t, "unprefixed message", err.(*CustomError).Message)
+}
+
+//////
+// MarshalJSON: retried flag, status code, and empty-tags omission.
+//////
+
+func TestCoverage_MarshalJSON_Branches(t *testing.T) {
+	cE := New(
+		"some message",
+		WithStatusCode(http.StatusServiceUnavailable),
+		WithRetryable(true),
+	).(*CustomError)
+
+	cE.SetRetried(true)
+
+	b, err := json.Marshal(cE)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &m))
+
+	assert.Equal(t, "some message", m["message"])
+	assert.Equal(t, true, m["retryable"])
+	assert.Equal(t, true, m["retried"])
+	assert.InEpsilon(t, float64(http.StatusServiceUnavailable), m["statusCode"], 0.001)
+
+	// Edge: no code and no tags -> keys omitted.
+	assert.NotContains(t, m, "code")
+	assert.NotContains(t, m, "tags")
+}
+
+//////
+// APIError: message-equals-status-text and message-equals-code branches.
+//////
+
+func TestCoverage_APIError_Branches(t *testing.T) {
+	// Edge: message equals the HTTP status text -> no duplicated text.
+	cE := New("Not Found", WithStatusCode(http.StatusNotFound)).(*CustomError)
+	assert.Equal(t, "Not Found (404)", cE.APIError())
+
+	// Edge: message equals the code -> code only, once.
+	viaCode := newInternal(WithErrorCode("E1010"))
+	assert.Equal(t, "E1010", viaCode.APIError())
+	assert.Equal(t, "E1010", viaCode.Error())
+
+	// Happy path: distinct message, code, and status.
+	full := New("some message", WithErrorCode("E1010"), WithStatusCode(http.StatusNotFound)).(*CustomError)
+	assert.Equal(t, "E1010: some message (404 - Not Found)", full.APIError())
+}
+
+//////
+// Copy: ignore and retried flags propagate.
+//////
+
+func TestCoverage_Copy_Flags(t *testing.T) {
+	src := &CustomError{Message: "some message", Retried: true, ignore: true}
+
+	target := Copy(src, &CustomError{})
+
+	assert.True(t, target.Retried)
+	assert.True(t, target.ignore)
+	assert.Equal(t, "some message", target.Message)
+}

--- a/customerror.go
+++ b/customerror.go
@@ -6,10 +6,12 @@ package customerror
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 
@@ -47,7 +49,18 @@ var reservedJSONKeys = map[string]struct{}{
 // are properly copied. This function is useful when you need to create a new
 // CustomError instance based on an existing one, while avoiding any shared
 // references to mutable fields.
+//
+// A nil `src` is a no-op (target is returned unchanged); a nil `target` is
+// replaced by a fresh CustomError so the call never panics.
 func Copy(src, target *CustomError) *CustomError {
+	if target == nil {
+		target = &CustomError{}
+	}
+
+	if src == nil {
+		return target
+	}
+
 	if src.Code != "" {
 		target.Code = src.Code
 	}
@@ -141,7 +154,8 @@ func Copy(src, target *CustomError) *CustomError {
 }
 
 // Process fields and add them to the error message. If `fields` is nil or
-// empty, the message is returned unchanged (no dangling ". Fields:").
+// empty, the message is returned unchanged (no dangling ". Fields:"). Fields
+// are sorted by key so the output is deterministic.
 func processFields(
 	errMsg string,
 	fields *sync.Map,
@@ -150,19 +164,21 @@ func processFields(
 		return errMsg
 	}
 
-	var b strings.Builder
+	pairs := []string{}
 
 	fields.Range(func(k, v interface{}) bool {
-		fmt.Fprintf(&b, " %v=%v,", k, v)
+		pairs = append(pairs, fmt.Sprintf("%v=%v", k, v))
 
 		return true
 	})
 
-	if b.Len() == 0 {
+	if len(pairs) == 0 {
 		return errMsg
 	}
 
-	return fmt.Sprintf("%s. Fields:%s", errMsg, strings.TrimSuffix(b.String(), ","))
+	sort.Strings(pairs)
+
+	return fmt.Sprintf("%s. Fields: %s", errMsg, strings.Join(pairs, ", "))
 }
 
 // addUserFieldsToJSON copies user-provided fields into the JSON map `temp`,
@@ -699,7 +715,10 @@ func (w *wrappedError) Unwrap() []error {
 // Wrap wraps `customError` together with the additional `errors`. The returned
 // error preserves the identity of every wrapped error, so errors.Is and
 // errors.As match against `customError` and each of `errors`. Nil errors are
-// ignored.
+// ignored: if `customError` is nil the first non-nil additional error takes
+// its place, if every error is nil, nil is returned, and if there is nothing
+// to wrap the single remaining error is returned as-is (no dangling
+// "Wrapped Error(s)" suffix).
 func Wrap(customError error, errors ...error) error {
 	nonNil := make([]error, 0, len(errors))
 
@@ -707,6 +726,18 @@ func Wrap(customError error, errors ...error) error {
 		if err != nil {
 			nonNil = append(nonNil, err)
 		}
+	}
+
+	if customError == nil {
+		if len(nonNil) == 0 {
+			return nil
+		}
+
+		customError, nonNil = nonNil[0], nonNil[1:]
+	}
+
+	if len(nonNil) == 0 {
+		return customError
 	}
 
 	return &wrappedError{
@@ -801,18 +832,21 @@ func Factory(message string, opts ...Option) *CustomError {
 	return cE
 }
 
-// IsCustomError checks if the error is a `CustomError`.
+// IsCustomError checks if the error is - or wraps - a `CustomError`
+// (it traverses the error chain, see errors.As).
 func IsCustomError(err error) bool {
-	_, ok := err.(*CustomError)
+	var cE *CustomError
 
-	return ok
+	return errors.As(err, &cE)
 }
 
-// To converts the error to a `CustomError`.
+// To converts the error to a `CustomError`. It traverses the error chain
+// (see errors.As), so a `CustomError` wrapped by fmt.Errorf ("%w") or `Wrap`
+// is found too; the first `CustomError` in the chain is returned.
 func To(err error) (*CustomError, bool) {
-	cE, ok := err.(*CustomError)
+	var cE *CustomError
 
-	if !ok {
+	if !errors.As(err, &cE) {
 		return nil, false
 	}
 
@@ -824,8 +858,14 @@ func To(err error) (*CustomError, bool) {
 // copy is returned - this makes it safe to use with shared sentinel errors. If
 // `err` isn't a custom error, a new custom error wrapping it (with the given
 // options) is returned.
+//
+// NOTE: Unlike `To`, `From` intentionally only treats a DIRECT `*CustomError`
+// specially - a custom error nested inside another error is wrapped like any
+// other error, so no outer context is ever dropped.
+//
+//nolint:errorlint
 func From(err error, opts ...Option) error {
-	if cE, ok := To(err); ok {
+	if cE, ok := err.(*CustomError); ok {
 		// Operate on a copy so the original error (which may be a shared
 		// sentinel) is never mutated.
 		finalCE := Copy(cE, &CustomError{})
@@ -843,10 +883,11 @@ func From(err error, opts ...Option) error {
 	return New(err.Error(), opts...)
 }
 
-// IsHTTPStatus checks if the error is a `CustomError` with the
-// specified HTTP status code.
+// IsHTTPStatus checks if the error is - or wraps - a `CustomError` with the
+// specified HTTP status code (the first `CustomError` in the chain is
+// checked, see errors.As).
 func IsHTTPStatus(err error, statusCode int) bool {
-	cE, ok := err.(*CustomError)
+	cE, ok := To(err)
 
 	if !ok {
 		return false
@@ -855,10 +896,11 @@ func IsHTTPStatus(err error, statusCode int) bool {
 	return cE.StatusCode == statusCode
 }
 
-// IsErrorCode checks if the error is a `CustomError` with the
-// specified code.
+// IsErrorCode checks if the error is - or wraps - a `CustomError` with the
+// specified code (the first `CustomError` in the chain is checked, see
+// errors.As).
 func IsErrorCode(err error, code string) bool {
-	cE, ok := err.(*CustomError)
+	cE, ok := To(err)
 
 	if !ok {
 		return false
@@ -867,9 +909,10 @@ func IsErrorCode(err error, code string) bool {
 	return cE.Code == code
 }
 
-// IsRetryable checks if the error is a retryable `CustomError`.
+// IsRetryable checks if the error is - or wraps - a retryable `CustomError`
+// (the first `CustomError` in the chain is checked, see errors.As).
 func IsRetryable(err error) bool {
-	cE, ok := err.(*CustomError)
+	cE, ok := To(err)
 
 	if !ok {
 		return false

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1,0 +1,215 @@
+// Copyright 2021 The customerror Authors. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// End-to-end tests: exercise the library the way an application would, from
+// catalog setup through an HTTP round trip to the JSON the client receives,
+// plus the i18n and retry journeys. Each scenario covers a happy path, a bad
+// path, and edge cases.
+
+package customerror
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2E_HTTPAPIErrorFlow simulates a service that registers its errors in a
+// catalog at startup, and returns them - enriched per-request - as JSON over
+// HTTP.
+func TestE2E_HTTPAPIErrorFlow(t *testing.T) {
+	// Application startup: build the error catalog. NOTE: the code is only the
+	// catalog KEY; set it on the error itself via WithErrorCode when it should
+	// travel with the error (message prefix, JSON, IsErrorCode).
+	catalog := MustNewCatalog("userservice")
+	catalog.
+		MustSet("USER_NOT_FOUND", "user",
+			WithErrorCode("USER_NOT_FOUND"),
+			WithStatusCode(http.StatusNotFound),
+			WithTag("user", "lookup"),
+		).
+		MustSet("RATE_LIMITED", "too many requests",
+			WithStatusCode(http.StatusTooManyRequests),
+			WithRetryable(true),
+		)
+
+	// The HTTP handler resolves catalog errors per request.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/", func(w http.ResponseWriter, r *http.Request) {
+		id := r.URL.Path[len("/users/"):]
+
+		if id == "42" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":"42"}`)
+
+			return
+		}
+
+		cE := catalog.MustGet("USER_NOT_FOUND", WithField("id", id))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(cE.StatusCode)
+
+		// NOTE: assert (not require) - this runs on the server goroutine, where
+		// FailNow is not allowed.
+		payload, err := json.Marshal(cE)
+		assert.NoError(t, err)
+		_, _ = w.Write(payload)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	get := func(path string) *http.Response {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+path, nil)
+		require.NoError(t, err)
+
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+
+		return resp
+	}
+
+	// Happy path: existing user.
+	resp := get("/users/42")
+
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Bad path: missing user - the client receives the structured error.
+	resp2 := get("/users/99")
+
+	defer func() { _ = resp2.Body.Close() }()
+
+	assert.Equal(t, http.StatusNotFound, resp2.StatusCode)
+
+	body, err := io.ReadAll(resp2.Body)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(body, &got))
+
+	assert.Equal(t, "user", got["message"])
+	assert.Equal(t, "USER_NOT_FOUND", got["code"])
+	assert.Equal(t, "99", got["id"])
+	assert.InEpsilon(t, float64(http.StatusNotFound), got["statusCode"], 0.001)
+
+	// Edge: per-request enrichment never leaks back into the catalog.
+	pristine := catalog.MustGet("USER_NOT_FOUND")
+	if pristine.Fields != nil {
+		_, leaked := pristine.Fields.Load("id")
+		assert.False(t, leaked, "per-request field must not pollute the catalog entry")
+	}
+
+	// The retrieved error is matchable by its code.
+	assert.True(t, IsErrorCode(pristine, "USER_NOT_FOUND"))
+}
+
+// TestE2E_RetryFlow simulates a client retrying an operation based on
+// IsRetryable, flipping SetRetried on a per-attempt copy, with the final
+// error wrapped and matched through the chain.
+func TestE2E_RetryFlow(t *testing.T) {
+	// A shared sentinel, as an application would declare at package level.
+	errUpstream := errors.New("connection reset")
+	rateLimited := Factory(
+		"too many requests",
+		WithStatusCode(http.StatusTooManyRequests),
+		WithErrorCode("RATE_LIMITED"),
+		WithRetryable(true),
+	)
+
+	attempts := 0
+	operation := func() error {
+		attempts++
+		if attempts < 3 {
+			return rateLimited.New(WithError(errUpstream))
+		}
+
+		return nil
+	}
+
+	// Happy path: retry until success.
+	var last error
+
+	for range 5 {
+		last = operation()
+		if last == nil {
+			break
+		}
+
+		require.True(t, IsRetryable(last), "should be marked retryable")
+
+		cE, ok := To(last)
+		require.True(t, ok)
+		cE.SetRetried(true)
+
+		// The shared factory is never mutated by per-attempt changes.
+		assert.False(t, rateLimited.Retried)
+	}
+
+	assert.NoError(t, last)
+	assert.Equal(t, 3, attempts)
+
+	// Bad path: a non-retryable error stops the loop logic.
+	fatal := New("some fatal problem")
+	assert.False(t, IsRetryable(fatal))
+
+	// Edge: matching through a wrapped chain - Wrap + fmt.Errorf.
+	failure := rateLimited.New(WithError(errUpstream))
+	wrapped := fmt.Errorf("job failed: %w", Wrap(failure, errors.New("cleanup also failed")))
+
+	assert.True(t, IsErrorCode(wrapped, "RATE_LIMITED"))
+	assert.True(t, IsHTTPStatus(wrapped, http.StatusTooManyRequests))
+	assert.True(t, IsRetryable(wrapped))
+	assert.ErrorIs(t, wrapped, errUpstream)
+}
+
+// TestE2E_I18nFlow exercises the full translation journey: registering a
+// language, translating catalog errors, and falling back gracefully.
+func TestE2E_I18nFlow(t *testing.T) {
+	// Startup: register a custom language (unique code "kw" to avoid polluting
+	// the package-global template singleton for other tests).
+	MustAddNewLanguage("kw", NewErrorPrefixMap(
+		"fallu a %s",
+		"%s invalidu",
+		"falta %s",
+		"%s riquisitu",
+		"%s nun s'atopa",
+	))
+
+	base := Factory(
+		"la conexón",
+		WithTranslation("kw", "la conexón"),
+		WithTranslation("en", "the connection"),
+	)
+
+	// Happy path: translated + prefixed message.
+	err := base.NewFailedToError(WithLanguage("kw"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fallu a la conexón")
+
+	// Happy path: built-in language via the same flow.
+	err = base.NewFailedToError(WithLanguage("en"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to the connection")
+
+	// Bad path: unknown language falls back to the default message.
+	err = base.NewFailedToError(WithLanguage("xv"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to la conexón")
+
+	// Edge: invalid language code is ignored gracefully (no panic, default
+	// message).
+	err = base.NewFailedToError(WithLanguage("not-a-lang"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to la conexón")
+}


### PR DESCRIPTION
## Summary

Codebase review pass over v2.0.0: fixes four reproducible nil-pointer panics, makes error-message field output deterministic, makes the `Is*`/`To` helpers work through wrapped errors, and raises test coverage to **97%** with new e2e and edge-path suites. Prepares the `v2.1.0` release (CHANGELOG included).

## Fixes (all reproduced with failing tests before the fix)

- **`Catalog.Set` + ignore option → panic in `Get`**: `Factory` returns `nil` when `WithIgnoreFunc`/`WithIgnoreString` fires; `Set` stored that `nil`, and a later `Get`/`MustGet` on the code panicked (`Copy(nil, …)` nil-dereference). `Set` now rejects it with the new `ErrCatalogNilEntry` (`CE_ERR_CATALOG_NIL_ENTRY`), and `Get` is defensive against nil/foreign entries stored directly into the map.
- **`Wrap(nil, …)` → panic**: `wrappedError.Error()` dereferenced a nil primary error. Now the first non-nil error is promoted to primary, all-nil returns `nil`, and with nothing to wrap the single error is returned as-is (also removes the dangling `". Wrapped Error(s): "` suffix `Wrap(err)` used to produce).
- **`Copy(nil, …)` / `Copy(…, nil)` → panic**: `Copy` is exported; it is now nil-safe on both sides.

## Improvements

- **Deterministic messages**: `Error()`/`APIError()` sort fields by key (`. Fields: a=1, b=2`); previously the order was random for >1 field (`sync.Map` range order).
- **Chain-aware helpers**: `IsCustomError`, `To`, `IsHTTPStatus`, `IsErrorCode`, `IsRetryable` now use `errors.As`, so a `CustomError` wrapped via `fmt.Errorf("%w", …)` or `Wrap` is found. `From` deliberately keeps its direct-assertion semantics (documented) so outer context is never dropped.

## Tests — coverage 92.9% → 97.0%

- **Regression tests** for each fix (happy/bad/edge, following `bugfixes_test.go` conventions) plus a 50-goroutine shared-error stress test (factory methods, catalog `MustGet`, `From`, template reads) — race detector clean.
- **New `e2e_test.go`** — full user journeys, each with happy/bad/edge paths:
  - catalog-driven HTTP API error flow over a real `httptest` round trip (structured JSON payload, per-request enrichment isolation, code matching);
  - retry loop driven by `IsRetryable`/`SetRetried` on per-attempt copies, with chain matching through `Wrap` + `fmt.Errorf("%w")`;
  - complete i18n journey: custom language registration, built-in languages, unknown/invalid-language fallbacks.
- **New `coverage_test.go`** — previously untested paths: `Must*` panic paths, nil receivers on `FormatError` and every instance factory method, `FormatError` root-language fallback (`pt-BR` → `pt`) and missing-template degradation, `MarshalJSON` branch coverage, `APIError` message==status-text / message==code branches, `GetRoot`/`GetLanguageErrorTypeMap` bad paths.
- `go vet`: clean. `golangci-lint v2.5.0` with repo config: **0 issues**.

No breaking changes — additive + bug fixes, so this is a minor bump (`v2.1.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kXcvPJYQaZtStJgVbDVYg