### PR TITLE
feat: catalog code stamping + JSON, thread-safe tags, linter adoption (v2.2.0)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,12 +26,9 @@ linters:
     - perfsprint
     - depguard
     - testifylint
-    # Linters introduced in golangci-lint v2 that are not part of this repo's
-    # v1 baseline and conflict with its established idioms; kept off so the v2
-    # migration preserves the previous effective rule set.
-    - noinlineerr # idiomatic `if err := f(); err != nil` is used throughout
-    - funcorder # repo groups code via "//////" section dividers, not ctor-first
-    - wsl_v5 # superseded ruleset; `wsl` (below) preserves the prior behavior
+    # Deprecated (since golangci-lint v2.2.0); replaced by wsl_v5, which is
+    # enabled via `default: all`.
+    - wsl
   settings:
     funlen:
       lines: 150
@@ -56,7 +53,7 @@ linters:
           - nlreturn
       - path: _test\.go
         linters:
-          - wsl
+          - wsl_v5 # same relaxation the old `wsl` had for tests
           - nlreturn
           - funlen
           - dupl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-07-03
+### Added
+- `Catalog` now implements `json.Marshaler`: `json.Marshal(catalog)` produces
+  `{"name": ..., "custom_errors": {"<CODE>": <entry>, ...}}` with deterministic
+  (sorted) keys, instead of an empty object (the underlying `*sync.Map` is not
+  JSON-marshalable); nil or foreign entries stored directly into the map are
+  skipped defensively.
+- The `Set` type (the `Tags` container) is now safe for concurrent use:
+  `Add`, `Remove`, `Contains`, `Empty`, `Size`, `Clear`, `Values`, `Each`,
+  `String`, and `MarshalJSON` are guarded by an internal `RWMutex`. Calling
+  other embedded treeset methods directly bypasses the lock (documented).
+
+### Changed
+- **Behavior change**: `Catalog.Set` now stamps the validated, uppercased
+  error code on the stored entry itself (`Code`), so errors retrieved from a
+  catalog carry their code by default - `Error()` gains the `CODE: ` prefix,
+  JSON output includes `code`, and `IsErrorCode` matches. An explicit
+  `WithErrorCode` still wins.
+- `Copy` no longer deadlocks when `src` and `target` share the same `Tags`
+  set, and merges tags via a snapshot so no lock is held across two sets.
+- Lint: adopted `noinlineerr`, `funcorder`, and `wsl_v5` (replacing the
+  deprecated `wsl`); constructors now precede methods and inline
+  `if err := ...; err != nil` was split codebase-wide. No behavior changes.
+
 ## [2.1.0] - 2026-07-03
 ### Changed
 - `IsCustomError`, `To`, `IsHTTPStatus`, `IsErrorCode`, and `IsRetryable` now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,10 @@ the `/v2` suffix; the package name is still `customerror`).
   code `gte=2`, status `100..511`. They must NEVER call `os.Exit`/`log.Fatalf`.
 - `From(*CustomError, …)` returns a modified COPY (never mutates the original);
   so `errors.Is(From(x,…), x)` is false for a `*CustomError` input.
+- Since v2.2.0 `Catalog.Set` stamps the code on the stored entry, so
+  catalog-derived errors print with the `CODE: ` prefix (an explicit
+  `WithErrorCode` wins). `Set` (Tags) construction goes through the unexported
+  `newSet()` - positional `&Set{…}` literals no longer compile (mutex field).
 
 ## Build / test / lint
 - `make test` / `make coverage` — `go test -race -cover` (passes; ~93%).
@@ -54,10 +58,10 @@ the `/v2` suffix; the package name is still `customerror`).
   CI pins **golangci-lint v2.5.0** + **Go 1.25** (`.github/workflows/go.yml`,
   `golangci/golangci-lint-action@v8`). A modern (v2.x) golangci-lint runs the
   config directly — no version gymnastics needed.
-  - The v2 migration disabled three linters that are new in v2 and clash with
-    the repo's idioms, to preserve the prior baseline: `noinlineerr`,
-    `funcorder`, `wsl_v5` (the old `wsl` stays). Re-enable deliberately if you
-    want to adopt them (each needs codebase-wide changes).
+  - Since v2.2.0 the config adopts `noinlineerr` (no
+    `if err := f(); err != nil` - use plain assignment + check), `funcorder`
+    (constructors/Factory sections precede Methods sections), and `wsl_v5`
+    (replaces the deprecated `wsl`; same `_test.go` relaxation as before).
   - `default: all` is strict: `intrange`/`copyloopvar` are on (use
     `for i := range n`); non-Latin template strings need a `gosmopolitan`
     exception (test files are already excluded) or `//nolint:gosmopolitan`.

--- a/catalog.go
+++ b/catalog.go
@@ -60,6 +60,48 @@ type (
 )
 
 //////
+// Factory.
+//////
+
+// NewErrorCode creates a new ErrorCode. It will be validated and stored upper
+// cased.
+func NewErrorCode(name string) (ErrorCode, error) {
+	eC := ErrorCode(strings.ToUpper(name))
+
+	err := eC.Validate()
+	if err != nil {
+		return "", err
+	}
+
+	return eC, nil
+}
+
+// NewCatalog creates a new Catalog.
+func NewCatalog(name string) (*Catalog, error) {
+	c := &Catalog{
+		ErrorCodeErrorMap: &sync.Map{},
+		Name:              name,
+	}
+
+	err := validate.Struct(c)
+	if err != nil {
+		return nil, ErrCatalogInvalidName
+	}
+
+	return c, nil
+}
+
+// MustNewCatalog creates a new Catalog. If an error occurs, panics.
+func MustNewCatalog(name string) *Catalog {
+	c, err := NewCatalog(name)
+	if err != nil {
+		panic(err)
+	}
+
+	return c
+}
+
+//////
 // Methods.
 //////
 
@@ -111,7 +153,8 @@ func (c *Catalog) Set(errorCode string, defaultMessage string, opts ...Option) (
 // MustSet a custom error to the catalog. Use options to set default and common
 // values such as fields, tags, etc. If an error occurs, panics.
 func (c *Catalog) MustSet(errorCode string, defaultMessage string, opts ...Option) *Catalog {
-	if _, err := c.Set(errorCode, defaultMessage, opts...); err != nil {
+	_, err := c.Set(errorCode, defaultMessage, opts...)
+	if err != nil {
 		panic(err)
 	}
 
@@ -202,44 +245,4 @@ func (c *Catalog) MarshalJSON() ([]byte, error) {
 		Name:         c.Name,
 		CustomErrors: entries,
 	})
-}
-
-//////
-// Factory.
-//////
-
-// NewErrorCode creates a new ErrorCode. It will be validated and stored upper
-// cased.
-func NewErrorCode(name string) (ErrorCode, error) {
-	eC := ErrorCode(strings.ToUpper(name))
-
-	if err := eC.Validate(); err != nil {
-		return "", err
-	}
-
-	return eC, nil
-}
-
-// NewCatalog creates a new Catalog.
-func NewCatalog(name string) (*Catalog, error) {
-	c := &Catalog{
-		ErrorCodeErrorMap: &sync.Map{},
-		Name:              name,
-	}
-
-	if err := validate.Struct(c); err != nil {
-		return nil, ErrCatalogInvalidName
-	}
-
-	return c, nil
-}
-
-// MustNewCatalog creates a new Catalog. If an error occurs, panics.
-func MustNewCatalog(name string) *Catalog {
-	c, err := NewCatalog(name)
-	if err != nil {
-		panic(err)
-	}
-
-	return c
 }

--- a/catalog.go
+++ b/catalog.go
@@ -1,6 +1,7 @@
 package customerror
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -47,6 +48,10 @@ type (
 	// Catalog contains a set of errors (customerrors).
 	Catalog struct {
 		// CustomErrors are the errors in the catalog.
+		//
+		// NOTE: The `json` tag only documents the shape - `encoding/json`
+		// cannot marshal a `*sync.Map`, so `MarshalJSON` is the source of
+		// truth for the catalog's JSON representation.
 		ErrorCodeErrorMap ErrorCodeErrorMap `json:"custom_errors"`
 
 		// Name of the catalog, usually, the name of the application.
@@ -76,6 +81,12 @@ func (e ErrorCode) Validate() error {
 // values such as fields, tags, etc. If the resulting error is nil (an ignore
 // option was triggered), nothing is stored and `ErrCatalogNilEntry` is
 // returned - a nil entry would otherwise panic on `Get`.
+//
+// The validated, uppercased code is also set on the stored entry itself
+// (`Code`), so errors retrieved from the catalog are identifiable by default:
+// `Error()` gains the "CODE: " prefix, the JSON output carries `code`, and
+// `IsErrorCode` matches. An explicit, non-empty code provided via
+// `WithErrorCode` wins - it is never overwritten.
 func (c *Catalog) Set(errorCode string, defaultMessage string, opts ...Option) (string, error) {
 	eC, err := NewErrorCode(errorCode)
 	if err != nil {
@@ -85,6 +96,11 @@ func (c *Catalog) Set(errorCode string, defaultMessage string, opts ...Option) (
 	cE := Factory(defaultMessage, opts...)
 	if cE == nil {
 		return "", ErrCatalogNilEntry
+	}
+
+	// Carry the code on the entry itself unless the caller explicitly set one.
+	if cE.Code == "" {
+		cE.Code = eC.String()
 	}
 
 	c.ErrorCodeErrorMap.Store(eC, cE)
@@ -144,6 +160,48 @@ func (c *Catalog) MustGet(errorCode string, opts ...Option) *CustomError {
 	}
 
 	return customErr
+}
+
+//////
+// Implementing the json.Marshaler interface.
+//////
+
+// MarshalJSON implements the json.Marshaler interface. It is the source of
+// truth for the catalog's JSON shape:
+//
+//	{"name": "<name>", "custom_errors": {"<CODE>": <entry>, ...}}
+//
+// `encoding/json` cannot marshal the underlying `*sync.Map`, so the entries
+// are snapshotted into a plain map - keyed by the error code - and each entry
+// is marshaled via its own `MarshalJSON`. `encoding/json` sorts map keys, so
+// the output is deterministic. Nil (or foreign) entries stored directly into
+// the map, bypassing `Set`, are defensively skipped.
+func (c *Catalog) MarshalJSON() ([]byte, error) {
+	entries := map[string]*CustomError{}
+
+	c.ErrorCodeErrorMap.Range(func(key, value interface{}) bool {
+		eC, ok := key.(ErrorCode)
+		if !ok {
+			return true
+		}
+
+		cE, ok := value.(*CustomError)
+		if !ok || cE == nil {
+			return true
+		}
+
+		entries[eC.String()] = cE
+
+		return true
+	})
+
+	return json.Marshal(struct {
+		Name         string                  `json:"name"`
+		CustomErrors map[string]*CustomError `json:"custom_errors"`
+	}{
+		Name:         c.Name,
+		CustomErrors: entries,
+	})
 }
 
 //////

--- a/catalog_features_test.go
+++ b/catalog_features_test.go
@@ -1,0 +1,135 @@
+// Copyright 2021 The customerror Authors. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// Tests for the v2.2.0 catalog features. Each block covers a happy path, a
+// bad path, and edge cases:
+//   - `Catalog.Set` stamps the validated, uppercased code on the stored entry
+//     unless an explicit `WithErrorCode` was provided.
+//   - `Catalog.MarshalJSON` produces a useful, deterministic JSON
+//     representation of the catalog.
+
+package customerror
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//////
+// Feature: Catalog.Set stamps the code on the entry.
+//////
+
+func TestFeature_CatalogSet_CodeOnEntry(t *testing.T) {
+	c := MustNewCatalog("myapp")
+
+	// Happy path: Set then Get - the entry carries the code by default, is
+	// matchable via IsErrorCode, prefixes Error(), and shows up in the JSON.
+	code, err := c.Set("USER_NOT_FOUND", "user not found")
+	require.NoError(t, err)
+	assert.Equal(t, "USER_NOT_FOUND", code)
+
+	entry, err := c.Get("USER_NOT_FOUND")
+	require.NoError(t, err)
+	assert.Equal(t, "USER_NOT_FOUND", entry.Code)
+	assert.True(t, IsErrorCode(entry, "USER_NOT_FOUND"))
+	assert.Equal(t, "USER_NOT_FOUND: user not found", entry.Error())
+
+	payload, err := json.Marshal(entry)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"code":"USER_NOT_FOUND","message":"user not found"}`, string(payload))
+
+	// Precedence: an explicit WithErrorCode must WIN over the catalog key.
+	c.MustSet("KEY_CODE", "some message", WithErrorCode("OTHER"))
+
+	entry = c.MustGet("KEY_CODE")
+	assert.Equal(t, "OTHER", entry.Code)
+	assert.True(t, IsErrorCode(entry, "OTHER"))
+	assert.False(t, IsErrorCode(entry, "KEY_CODE"))
+	assert.Equal(t, "OTHER: some message", entry.Error())
+
+	// Edge: a lowercase input code is uppercased on the entry (NewErrorCode
+	// stores codes uppercased).
+	code, err = c.Set("lower_code", "some message")
+	require.NoError(t, err)
+	assert.Equal(t, "LOWER_CODE", code)
+	assert.Equal(t, "LOWER_CODE", c.MustGet("lower_code").Code)
+
+	// Edge: when Code == Message, Error() collapses to just the code (no
+	// "CODE: CODE" duplication).
+	c.MustSet("E1010", "E1010")
+	assert.Equal(t, "E1010", c.MustGet("E1010").Error())
+
+	// Edge: the stored entry is not mutated when a Get copy is modified (the
+	// existing copy-on-Get guarantee still holds for the auto-set code).
+	mutated := c.MustGet("USER_NOT_FOUND")
+	mutated.Code = "MUTATED"
+	mutated.SetMessage("mutated message")
+
+	fresh := c.MustGet("USER_NOT_FOUND")
+	assert.Equal(t, "USER_NOT_FOUND", fresh.Code)
+	assert.Equal(t, "user not found", fresh.Message)
+
+	// Bad path: an invalid code neither stores nor stamps anything.
+	code, err = c.Set("BAD CODE!", "some message")
+	require.Error(t, err)
+	assert.Empty(t, code)
+}
+
+//////
+// Feature: Catalog.MarshalJSON.
+//////
+
+func TestFeature_CatalogMarshalJSON(t *testing.T) {
+	// Happy path: a catalog with 2+ entries marshals with its name, the codes
+	// as keys, and each entry payload (message/code/statusCode) marshaled via
+	// CustomError.MarshalJSON.
+	c := MustNewCatalog("myapp")
+	c.
+		MustSet("USER_NOT_FOUND", "user not found", WithStatusCode(http.StatusNotFound)).
+		MustSet("RATE_LIMITED", "too many requests", WithStatusCode(http.StatusTooManyRequests))
+
+	payload, err := json.Marshal(c)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"name": "myapp",
+		"custom_errors": {
+			"RATE_LIMITED": {"code":"RATE_LIMITED","message":"too many requests","statusCode":429},
+			"USER_NOT_FOUND": {"code":"USER_NOT_FOUND","message":"user not found","statusCode":404}
+		}
+	}`, string(payload))
+
+	// Edge: deterministic output - marshaling twice is byte-identical
+	// (encoding/json sorts map keys).
+	payload2, err := json.Marshal(c)
+	require.NoError(t, err)
+	assert.Equal(t, payload, payload2)
+
+	// Edge: an empty catalog marshals to an empty (but present) map.
+	empty := MustNewCatalog("emptyapp")
+
+	payload, err = json.Marshal(empty)
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"emptyapp","custom_errors":{}}`, string(payload))
+
+	// Bad path (defensive): nil or foreign entries stored directly into the
+	// map (bypassing Set) are skipped without panicking.
+	poisoned := MustNewCatalog("poisonedapp")
+	poisoned.MustSet("OK_CODE", "some message")
+	poisoned.ErrorCodeErrorMap.Store(ErrorCode("NIL_TYPED"), (*CustomError)(nil))
+	poisoned.ErrorCodeErrorMap.Store(ErrorCode("NIL_IFACE"), nil)
+	poisoned.ErrorCodeErrorMap.Store("foreign_key", Factory("some message"))
+
+	payload, err = json.Marshal(poisoned)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"name": "poisonedapp",
+		"custom_errors": {
+			"OK_CODE": {"code":"OK_CODE","message":"some message"}
+		}
+	}`, string(payload))
+}

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -68,7 +68,9 @@ func TestNewCatalog(t *testing.T) {
 			// error.
 			cEInvalidRequestBody := cEInvalidRequestBodyErr.New(WithLanguage("pt-BR"), WithError(errors.New("some error")))
 
-			if cEInvalidRequestBody.Error() != "corpo da solicitação inválido. Original Error: some error" {
+			// Since v2.2.0 catalog entries carry their code, so Error() gains
+			// the "CODE: " prefix.
+			if cEInvalidRequestBody.Error() != "INVALID_REQUEST_BODY: corpo da solicitação inválido. Original Error: some error" {
 				t.Errorf("NewCatalog() error = %v, wantErr %v", err, tt.wantErr)
 
 				return
@@ -83,8 +85,8 @@ func TestNewCatalog(t *testing.T) {
 
 			cEE1010 := cEE1010Err.New(WithLanguage("es-ES"))
 
-			if cEE1010.Error() != "resposta inválida" {
-				t.Errorf("NewCatalog() error = %v, wantErr %v", err, "resposta inválida")
+			if cEE1010.Error() != "E1010: resposta inválida" {
+				t.Errorf("NewCatalog() error = %v, wantErr %v", err, "E1010: resposta inválida")
 
 				return
 			}

--- a/customerror.go
+++ b/customerror.go
@@ -909,7 +909,8 @@ func New(message string, opts ...Option) error {
 		return nil
 	}
 
-	if err := validate.Struct(cE); err != nil {
+	err := validate.Struct(cE)
+	if err != nil {
 		log.Panicf("Invalid custom error. %s\n", err)
 	}
 

--- a/customerror.go
+++ b/customerror.go
@@ -140,14 +140,20 @@ func Copy(src, target *CustomError) *CustomError {
 	}
 
 	// Merge the tags.
-	if src.Tags != nil {
+	//
+	// NOTE: When src and target share the very same Set (same pointer) there
+	// is nothing to merge - and it must be skipped so the target's write lock
+	// is never requested while iterating the (same) source.
+	if src.Tags != nil && src.Tags != target.Tags {
 		if target.Tags == nil {
-			target.Tags = &Set{treeset.NewWithStringComparator()}
+			target.Tags = newSet()
 		}
 
-		src.Tags.Each(func(_ int, value interface{}) {
+		// Snapshot the source values first so no lock is held on the source
+		// while the target is being mutated.
+		for _, value := range src.Tags.Values() {
 			target.Tags.Add(value)
-		})
+		}
 	}
 
 	return target
@@ -208,21 +214,117 @@ func addUserFieldsToJSON(temp map[string]interface{}, fields *sync.Map) {
 // Set is a wrapper around the treeset.Set, providing a collection
 // that stores unique elements in a sorted order. It is used in the
 // CustomError struct to maintain a sorted set of tags.
+//
+// The methods defined on Set itself - `Add`, `Remove`, `Contains`, `Empty`,
+// `Size`, `Clear`, `Values`, `Each`, `String`, and `MarshalJSON` - are safe
+// for concurrent use by multiple goroutines. Calling any other method of the
+// embedded treeset.Set directly (e.g. `Iterator`, `UnmarshalJSON`) bypasses
+// the lock and is NOT safe for concurrent use.
 type Set struct {
 	*treeset.Set
+
+	// mu guards the embedded treeset.Set.
+	mu sync.RWMutex
+}
+
+// newSet creates a new Set, optionally initialized with the given values.
+func newSet(values ...interface{}) *Set {
+	return &Set{Set: treeset.NewWithStringComparator(values...)}
+}
+
+// Add adds the given items to the set. Safe for concurrent use.
+func (s *Set) Add(items ...interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Set.Add(items...)
+}
+
+// Remove removes the given items from the set. Safe for concurrent use.
+func (s *Set) Remove(items ...interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Set.Remove(items...)
+}
+
+// Contains checks whether the set contains all the given items. Safe for
+// concurrent use.
+func (s *Set) Contains(items ...interface{}) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Set.Contains(items...)
+}
+
+// Empty checks whether the set has no elements. Safe for concurrent use.
+func (s *Set) Empty() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Set.Empty()
+}
+
+// Size returns the number of elements in the set. Safe for concurrent use.
+func (s *Set) Size() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Set.Size()
+}
+
+// Clear removes all elements from the set. Safe for concurrent use.
+func (s *Set) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Set.Clear()
+}
+
+// Values returns all elements in the set, sorted. Safe for concurrent use.
+func (s *Set) Values() []interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Set.Values()
+}
+
+// Each calls the given function once for each element, in sorted order. Safe
+// for concurrent use.
+//
+// NOTE: `f` must NOT call methods of the same Set (the lock is held for the
+// whole iteration); snapshot with `Values` first if that is needed.
+func (s *Set) Each(f func(index int, value interface{})) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	s.Set.Each(f)
 }
 
 // String implements the Stringer interface for the Set type.
 // It returns a comma-separated string representation of all elements
-// in the set, useful for debugging and error message formatting.
+// in the set, useful for debugging and error message formatting. Safe for
+// concurrent use.
 func (s *Set) String() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	items := []string{}
 
-	s.Each(func(_ int, value interface{}) {
+	s.Set.Each(func(_ int, value interface{}) {
 		items = append(items, fmt.Sprintf("%v", value))
 	})
 
 	return strings.Join(items, ", ")
+}
+
+// MarshalJSON implements the json.Marshaler interface, delegating to the
+// embedded treeset.Set implementation. Safe for concurrent use.
+func (s *Set) MarshalJSON() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.Set.MarshalJSON()
 }
 
 // CustomError is the base block to create custom errors. It provides context -

--- a/customerror_test.go
+++ b/customerror_test.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/emirpasic/gods/sets/treeset"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -370,7 +369,7 @@ func Test_CustomError_MarshalJSON(t *testing.T) {
 				Fields:     &fields,
 				Message:    "An error occurred",
 				StatusCode: http.StatusBadRequest,
-				Tags:       &Set{treeset.NewWithStringComparator("tag1", "tag2")},
+				Tags:       newSet("tag1", "tag2"),
 				ignore:     false,
 			},
 			expected: `{"code":"E1010","field1":"value1","field2":2,"message":"An error occurred. Original Error: Some error","statusCode":400,"tags":["tag1","tag2"]}`,
@@ -411,7 +410,7 @@ func Test_CustomError_Error(t *testing.T) {
 				Fields:     &fields,
 				Message:    "An error occurred",
 				StatusCode: http.StatusBadRequest,
-				Tags:       &Set{treeset.NewWithStringComparator("tag1", "tag2")},
+				Tags:       newSet("tag1", "tag2"),
 				ignore:     false,
 			},
 			expected: []string{"E1010", "An error occurred", "Original Error: Some error", "Tags", "tag1", "tag2", "Fields:", "field1=value1", "field2=2"},
@@ -435,7 +434,7 @@ func Test_CustomError_Error(t *testing.T) {
 }
 
 func Test_CustomError_String(t *testing.T) {
-	s := &Set{treeset.NewWithStringComparator("tag1", "tag2")}
+	s := newSet("tag1", "tag2")
 
 	expected := "tag1, tag2"
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -26,13 +26,12 @@ import (
 // catalog at startup, and returns them - enriched per-request - as JSON over
 // HTTP.
 func TestE2E_HTTPAPIErrorFlow(t *testing.T) {
-	// Application startup: build the error catalog. NOTE: the code is only the
-	// catalog KEY; set it on the error itself via WithErrorCode when it should
-	// travel with the error (message prefix, JSON, IsErrorCode).
+	// Application startup: build the error catalog. NOTE: since v2.2.0 Set
+	// also stamps the code on the entry itself, so it travels with the error
+	// (message prefix, JSON, IsErrorCode) without an explicit WithErrorCode.
 	catalog := MustNewCatalog("userservice")
 	catalog.
 		MustSet("USER_NOT_FOUND", "user",
-			WithErrorCode("USER_NOT_FOUND"),
 			WithStatusCode(http.StatusNotFound),
 			WithTag("user", "lookup"),
 		).

--- a/example_test.go
+++ b/example_test.go
@@ -46,7 +46,8 @@ func ExampleNew() {
 	}
 
 	// Case: Without `id`, returns `ErrMissingID`.
-	if err := SomeFunc(""); err != nil {
+	err := SomeFunc("")
+	if err != nil {
 		fmt.Println(errors.Is(err, ErrMissingID)) // true
 
 		var cE *CustomError
@@ -58,13 +59,14 @@ func ExampleNew() {
 	}
 
 	// Case: With `id`, returns dynamic error.
-	if err := SomeFunc("12345"); err != nil {
+	errDynamic := SomeFunc("12345")
+	if errDynamic != nil {
 		var cE *CustomError
-		if errors.As(err, &cE) {
+		if errors.As(errDynamic, &cE) {
 			fmt.Println(cE.StatusCode) // 500
 		}
 
-		fmt.Println(err) // E1523: failed to write to disk (500 - Internal Server Error)
+		fmt.Println(errDynamic) // E1523: failed to write to disk (500 - Internal Server Error)
 	}
 
 	// output:
@@ -108,7 +110,8 @@ func ExampleNew_marshalJSON() {
 	errA := NewMissingError("id")
 	errB := NewMissingError("name", WithError(errA))
 
-	if err := json.NewEncoder(&buf).Encode(errB); err != nil {
+	err := json.NewEncoder(&buf).Encode(errB)
+	if err != nil {
 		panic(err)
 	}
 
@@ -573,10 +576,11 @@ func ExampleNew_newRetryableError() {
 	)
 
 	// Execute the request with retry logic.
-	if err := r1.Run(func() error {
+	err := r1.Run(func() error {
 		// Throw the retryable error.
 		return retryableCE
-	}); err != nil {
+	})
+	if err != nil {
 		fmt.Println(err)
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -410,9 +410,9 @@ func ExampleNew_i18n() {
 	fmt.Println(err.NewInvalidError())
 
 	// output:
-	// ruta de disco duro inválido
-	// chemin de disque dur invalide
-	// invalid hard drive path
+	// ERR_INVALID_HARD_DRIVE_PATH: ruta de disco duro inválido
+	// ERR_INVALID_HARD_DRIVE_PATH: chemin de disque dur invalide
+	// ERR_INVALID_HARD_DRIVE_PATH: invalid hard drive path
 }
 
 // ExampleNew_i18n demonstrates how to create an error catalog with translations
@@ -519,10 +519,10 @@ func ExampleNew_i18nSetupNewLang() {
 	fmt.Println(err.NewInvalidError())
 
 	// output:
-	// ruta de disco duro inválido
-	// chemin de disque dur invalide
-	// ハードドライブのパス が無効です
-	// invalid hard drive path
+	// ERR_INVALID_HARD_DRIVE_PATH: ruta de disco duro inválido
+	// ERR_INVALID_HARD_DRIVE_PATH: chemin de disque dur invalide
+	// ERR_INVALID_HARD_DRIVE_PATH: ハードドライブのパス が無効です
+	// ERR_INVALID_HARD_DRIVE_PATH: invalid hard drive path
 }
 
 type CustomClassifier struct{}

--- a/i18n.md
+++ b/i18n.md
@@ -106,9 +106,9 @@ func ExampleNew_i18n() {
 	fmt.Println(err.NewInvalidError())
 
 	// output:
-	// ruta de disco duro inválido
-	// chemin de disque dur invalide
-	// invalid hard drive path
+	// ERR_INVALID_HARD_DRIVE_PATH: ruta de disco duro inválido
+	// ERR_INVALID_HARD_DRIVE_PATH: chemin de disque dur invalide
+	// ERR_INVALID_HARD_DRIVE_PATH: invalid hard drive path
 }
 ```
 
@@ -223,9 +223,9 @@ func ExampleNew_i18nSetupNewLang() {
 	fmt.Println(err.NewInvalidError())
 
 	// output:
-	// ruta de disco duro inválido
-	// chemin de disque dur invalide
-	// ハードドライブのパス が無効です
-	// invalid hard drive path
+	// ERR_INVALID_HARD_DRIVE_PATH: ruta de disco duro inválido
+	// ERR_INVALID_HARD_DRIVE_PATH: chemin de disque dur invalide
+	// ERR_INVALID_HARD_DRIVE_PATH: ハードドライブのパス が無効です
+	// ERR_INVALID_HARD_DRIVE_PATH: invalid hard drive path
 }
 ```

--- a/language.go
+++ b/language.go
@@ -59,6 +59,22 @@ type (
 )
 
 //////
+// Factory.
+//////
+
+// NewLanguage creates a new Lang.
+func NewLanguage(lang string) (Language, error) {
+	l := Language(lang)
+
+	err := l.Validate()
+	if err != nil {
+		return "", err
+	}
+
+	return l, nil
+}
+
+//////
 // Methods.
 //////
 
@@ -85,19 +101,4 @@ func (l Language) GetRoot() string {
 	}
 
 	return ""
-}
-
-//////
-// Factory.
-//////
-
-// NewLanguage creates a new Lang.
-func NewLanguage(lang string) (Language, error) {
-	l := Language(lang)
-
-	if err := l.Validate(); err != nil {
-		return "", err
-	}
-
-	return l, nil
 }

--- a/languageprefixtemplate.go
+++ b/languageprefixtemplate.go
@@ -233,7 +233,8 @@ func MustAddNewLanguage(
 	language string,
 	errorTypePrefixTemplateMap ErrorPrefixMap,
 ) {
-	if err := AddNewLanguage(language, errorTypePrefixTemplateMap); err != nil {
+	err := AddNewLanguage(language, errorTypePrefixTemplateMap)
+	if err != nil {
 		panic(err)
 	}
 }

--- a/languageprefixtemplate_test.go
+++ b/languageprefixtemplate_test.go
@@ -60,13 +60,14 @@ func TestSetErrorTypePrefixTemplateMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := AddNewLanguage("bl-BA", NewErrorPrefixMap(
+			err := AddNewLanguage("bl-BA", NewErrorPrefixMap(
 				"blablabla %s",
 				"blebleble %s",
 				"bliblibli %s",
 				"blobloblo %s",
 				"blublublu %s",
-			)); (err != nil) != tt.wantErr {
+			))
+			if (err != nil) != tt.wantErr {
 				t.Errorf("SetErrorTypePrefixTemplateMap() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/options.go
+++ b/options.go
@@ -16,8 +16,6 @@ package customerror
 import (
 	"strings"
 	"sync"
-
-	"github.com/emirpasic/gods/sets/treeset"
 )
 
 //////
@@ -114,7 +112,7 @@ func WithIgnoreString(s ...string) Option {
 func WithTag(tag ...string) Option {
 	return func(cE *CustomError) {
 		if cE.Tags == nil {
-			cE.Tags = &Set{treeset.NewWithStringComparator()}
+			cE.Tags = newSet()
 		}
 
 		for _, t := range tag {

--- a/set_concurrency_test.go
+++ b/set_concurrency_test.go
@@ -1,0 +1,249 @@
+// Copyright 2021 The customerror Authors. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// Concurrency tests for the Set type (the Tags container). Each block covers
+// a happy path, a bad path, and edge cases. These tests are meant to be run
+// with the race detector enabled (`go test -race`).
+
+package customerror
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//////
+// Happy path: concurrent WithTag on the SAME *CustomError while other
+// goroutines read it (Error, json.Marshal). No data race, and afterwards all
+// tags are present and sorted.
+//////
+
+func TestSetConcurrency_WithTagWhileReading(t *testing.T) {
+	const writers = 50
+
+	// Seed the first tag at construction time so the Tags container itself is
+	// initialized before the goroutines start (lazy initialization of the
+	// `Tags` FIELD is the caller's to sequence; the Set is what's safe for
+	// concurrent use).
+	err := New("shared error", WithTag("tag-00"))
+
+	cE, ok := To(err)
+	require.True(t, ok)
+
+	var wg sync.WaitGroup
+
+	// Writers: each applies its own tag via WithTag on the SAME instance
+	// (re-adding "tag-00" concurrently is fine - it's a set).
+	for i := range writers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			WithTag(fmt.Sprintf("tag-%02d", i))(cE)
+		}()
+	}
+
+	// Readers: Error() and json.Marshal run concurrently with the writers.
+	for range 10 {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			assert.NotEmpty(t, cE.Error())
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			b, mErr := json.Marshal(cE)
+			assert.NoError(t, mErr)
+			assert.NotEmpty(t, b)
+		}()
+	}
+
+	wg.Wait()
+
+	// All tags must be present, and String() must render them sorted.
+	require.NotNil(t, cE.Tags)
+	assert.Equal(t, writers, cE.Tags.Size())
+
+	expected := make([]string, 0, writers)
+
+	for i := range writers {
+		expected = append(expected, fmt.Sprintf("tag-%02d", i))
+	}
+
+	assert.Equal(t, strings.Join(expected, ", "), cE.Tags.String())
+	assert.Contains(t, cE.Error(), "Tags: "+strings.Join(expected, ", "))
+}
+
+//////
+// Happy path: a mixed concurrent workload over the locked Set API
+// (Add/Remove/Contains/Values/Each/Size/Empty/String/Clear).
+//////
+
+func TestSetConcurrency_MixedAPI(t *testing.T) {
+	const items = 50
+
+	s := newSet()
+
+	var wg sync.WaitGroup
+
+	for i := range items {
+		wg.Add(2)
+
+		// Writer.
+		go func() {
+			defer wg.Done()
+
+			s.Add(fmt.Sprintf("item-%02d", i))
+		}()
+
+		// Reader: none of these must race with the writers above.
+		go func() {
+			defer wg.Done()
+
+			_ = s.Contains(fmt.Sprintf("item-%02d", i))
+			_ = s.Values()
+			_ = s.Size()
+			_ = s.Empty()
+			_ = s.String()
+
+			s.Each(func(_ int, value interface{}) {
+				assert.NotNil(t, value)
+			})
+		}()
+	}
+
+	wg.Wait()
+
+	// Every item must have made it in exactly once.
+	assert.Equal(t, items, s.Size())
+	assert.False(t, s.Empty())
+	assert.True(t, s.Contains("item-00", fmt.Sprintf("item-%02d", items-1)))
+	assert.Len(t, s.Values(), items)
+
+	// Concurrent removals of the first half.
+	half := items / 2
+
+	for i := range half {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			s.Remove(fmt.Sprintf("item-%02d", i))
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, items-half, s.Size())
+	assert.False(t, s.Contains("item-00"))
+
+	// Clear empties the set.
+	s.Clear()
+
+	assert.True(t, s.Empty())
+	assert.Equal(t, 0, s.Size())
+}
+
+//////
+// Edge case: Copy where src and target share the SAME Tags pointer must not
+// deadlock (it would mean iterating a Set while adding to the very same Set).
+//////
+
+func TestSetConcurrency_CopySharedTagsNoDeadlock(t *testing.T) {
+	shared := newSet("a", "b")
+
+	src := &CustomError{Message: "source error", Tags: shared}
+	target := &CustomError{Message: "target error", Tags: shared}
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		_ = Copy(src, target)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Copy deadlocked when src and target share the same Tags pointer")
+	}
+
+	// The shared set is untouched and the copy semantics are preserved.
+	assert.Equal(t, "a, b", shared.String())
+	assert.Same(t, shared, target.Tags)
+	assert.Equal(t, "source error", target.Message)
+}
+
+//////
+// Edge case: String() determinism is preserved - tags added concurrently and
+// out of order still render sorted ("a, b, c").
+//////
+
+func TestSetConcurrency_StringDeterminism(t *testing.T) {
+	s := newSet()
+
+	var wg sync.WaitGroup
+
+	for _, tag := range []string{"c", "a", "b"} {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			s.Add(tag)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, "a, b, c", s.String())
+}
+
+//////
+// Bad path: a fresh (empty) Set must not panic - every locked method behaves
+// sanely with no elements.
+//////
+
+func TestSetConcurrency_EmptySetDoesNotPanic(t *testing.T) {
+	s := newSet()
+
+	assert.NotPanics(t, func() {
+		assert.True(t, s.Empty())
+		assert.Equal(t, 0, s.Size())
+		assert.Empty(t, s.Values())
+		assert.Empty(t, s.String())
+		assert.False(t, s.Contains("nope"))
+
+		called := false
+
+		s.Each(func(_ int, _ interface{}) {
+			called = true
+		})
+
+		assert.False(t, called)
+
+		// Mutators on an empty set are no-ops, not panics.
+		s.Remove("nope")
+		s.Clear()
+
+		// JSON of an empty set is an empty array.
+		b, err := json.Marshal(s)
+		assert.NoError(t, err)
+		assert.JSONEq(t, "[]", string(b))
+	})
+}


### PR DESCRIPTION
## Summary

Implements all four improvement suggestions from the v2.1.0 review, prepared as **v2.2.0**. The two feature tracks were developed in parallel (isolated worktrees) and integrated; the linter adoption ran last since it touches files across the repo.

- **`Catalog.Set` stamps the code on the entry** — errors retrieved from a catalog now carry their code by default: `Error()` gains the `CODE: ` prefix, JSON output includes `code`, and `IsErrorCode` matches. An explicit `WithErrorCode` still wins. *Behavior change, called out in the CHANGELOG; `i18n.md` example outputs synced.*
- **`Catalog` implements `json.Marshaler`** — `{"name": ..., "custom_errors": {"<CODE>": <entry>, ...}}` with deterministic keys, instead of the previous empty `{}` (a `*sync.Map` isn't JSON-marshalable); nil/foreign entries skipped defensively.
- **Thread-safe `Tags` set** — `Add`, `Remove`, `Contains`, `Empty`, `Size`, `Clear`, `Values`, `Each`, `String`, and `MarshalJSON` are guarded by an internal `RWMutex` (documented: direct embedded-treeset calls bypass the lock). `Copy` gained a same-pointer deadlock guard and merges tags via snapshot. Construction goes through a new unexported `newSet()`.
- **Linter adoption** — re-enabled `noinlineerr` and `funcorder`; replaced deprecated `wsl` with `wsl_v5` (same test-file relaxation). Factory sections now precede Methods sections; inline `if err := ...; err != nil` split codebase-wide. No behavior changes.

## Tests

Everything is covered with tests (happy/bad/edge per feature): `catalog_features_test.go` (code stamping incl. `WithErrorCode` precedence, uppercasing, stored-entry isolation; MarshalJSON incl. determinism, empty catalog, nil-entry defense) and `set_concurrency_test.go` (50 concurrent writers racing readers, mixed-op workload, shared-pointer `Copy` edge, determinism, empty-set paths).

- `go test -race -count=2`: pass, **97.3% coverage** (was 97.0%).
- `go vet` clean; `golangci-lint v2.5.0` with the *stricter* config: **0 issues**.

## CHANGELOG

Included as v2.2.0 (minor bump: additive features + a documented behavior change in catalog output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kXcvPJYQaZtStJgVbDVYg